### PR TITLE
update qemu and riscv-gnu-toolchain repos to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "qemu"]
 	path = qemu
-	url = git://github.com/palmer-dabbelt/qemu.git
+	url = https://github.com/palmer-dabbelt/qemu.git
 [submodule "linux"]
 	path = linux
 	url = git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux.git
@@ -9,7 +9,7 @@
 	url = git://git.buildroot.net/buildroot
 [submodule "riscv-gnu-toolchain"]
 	path = riscv-gnu-toolchain
-	url = git://github.com/riscv/riscv-gnu-toolchain.git
+	url = https://github.com/riscv/riscv-gnu-toolchain.git
 [submodule "crosstool-ng"]
 	path = crosstool-ng
 	url = https://github.com/crosstool-ng/crosstool-ng


### PR DESCRIPTION
Github no longer allows repo links to start with git:// [1]

Update submodule links to use https.

[1] https://github.blog/2021-09-01-improving-git-protocol-security-github/