### PR TITLE
Makefile tweaks to simplify running in "my" CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,9 @@ check/dt_check/log: \
 	@rm -rf $(dir $@)
 	@mkdir -p $(dir $@)
 	$(MAKE) -C $(abspath $(LINUX)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) defconfig
-	$(MAKE) -C $(abspath $(LINUX)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) dt_binding_check dtbs_check |& tee $@
+	- $(MAKE) -C $(abspath $(LINUX)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) dt_binding_check |& tee $@
+	$(MAKE) -C $(abspath $(LINUX)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) dtbs_check |& tee -a $@
+
 
 check/dt_check/report: check/dt_check/log
 	cat $< | grep -v '^  ' | grep -v '^make' > $@

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,18 @@ check:
 clean:
 	tools/git-clean-recursive
 
-GCC = toolchain/install/bin/riscv64-unknown-linux-gcc
-SPARSE = sparse/install/bin/sparse
+GCC_DEFAULT := toolchain/install/bin/riscv64-unknown-linux-gnu-gcc
+GCC ?= $(GCC_DEFAULT)
+SPARSE ?= sparse/install/bin/sparse
 PATH := $(abspath $(dir $(GCC))):$(abspath $(dir $(SPARSE))):$(PATH)
+LINUX ?= linux
 export PATH
 
+ifneq ($(GCC),$(GCC_DEFAULT))
+toolchain/install.stamp:
+	mkdir -p $(dir $@)
+	date > $@
+else
 # Builds GCC from the RISC-V integration repo
 $(GCC): toolchain/install.stamp
 
@@ -34,6 +41,7 @@ toolchain/install.stamp: toolchain/Makefile
 toolchain/Makefile: riscv-gnu-toolchain/configure
 	mkdir -p $(dir $@)
 	env -C $(dir $@) $(abspath $<) --prefix="$(abspath $(dir $@)/install)" --enable-linux
+endif
 
 # Builds QEMU from git source.  There's been an attempt at detecting
 # dependencies here, but nothing serious.
@@ -75,71 +83,71 @@ kernel/%/arch/riscv/boot/Image: kernel/%/stamp
 kernel/%/stamp: \
 		kernel/%/.config \
 		toolchain/install.stamp \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e) \
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e) \
 		$(GCC) $(SPARSE)
-	$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- C=1 CF="-Wno-sparse-error"
+	$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- C=1 CF="-Wno-sparse-error"
 	date > $@
 
 kernel/rv64gc/%/.config: \
-		linux/arch/riscv/configs/% \
+		$(LINUX)/arch/riscv/configs/% \
 		toolchain/install.stamp \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e | grep Kconfig)
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e | grep Kconfig)
 	mkdir -p $(dir $@)
 	rm -f $@
-	$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- $(notdir $<)
+	$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- $(notdir $<)
 	touch -c $@
 
 kernel/rv32gc/%/.config: \
-		linux/arch/riscv/configs/rv32_% \
+		$(LINUX)/arch/riscv/configs/rv32_% \
 		toolchain/install.stamp \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e | grep Kconfig)
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e | grep Kconfig)
 	mkdir -p $(dir $@)
 	rm -f $@
-	$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- $(notdir $<)
+	$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- $(notdir $<)
 	touch -c $@
 
 kernel/rv64gc/%/.config: \
-		configs/linux/% \
-		linux/arch/riscv/configs/defconfig \
+		configs/$(LINUX)/% \
+		$(LINUX)/arch/riscv/configs/defconfig \
 		toolchain/install.stamp \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e | grep Kconfig)
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e | grep Kconfig)
 	mkdir -p $(dir $@)
 	rm -f $@
-	$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- defconfig
+	$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- defconfig
 	cat $< >> $@
-	-$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- olddefconfig
+	-$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- olddefconfig
 	tools/checkconfig $< $@ || mv $@ $@.broken
-	-$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- savedefconfig
+	-$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- savedefconfig
 	touch -c $@
 
 kernel/rv32gc/%/.config: \
-		configs/linux/% \
-		linux/arch/riscv/configs/defconfig \
+		configs/$(LINUX)/% \
+		$(LINUX)/arch/riscv/configs/defconfig \
 		toolchain/install.stamp \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e | grep Kconfig)
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e | grep Kconfig)
 	mkdir -p $(dir $@)
 	rm -f $@
-	$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- rv32_defconfig
+	$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- rv32_defconfig
 	cat $< >> $@
-	-$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- olddefconfig
+	-$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- olddefconfig
 	tools/checkconfig $< $@ || mv $@ $@.broken
-	-$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- savedefconfig
+	-$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- savedefconfig
 	touch -c $@
 
 kernel/rv64gc/all%config/.config: \
 		toolchain/install.stamp \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e | grep Kconfig)
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e | grep Kconfig)
 	mkdir -p $(dir $@)
 	rm -f $@
-	$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- KCONFIG_ALLCONFIG=$(abspath linux/arch/riscv/configs/64-bit.config) $(word 3,$(subst /, ,$@))
+	$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- KCONFIG_ALLCONFIG=$(abspath $(LINUX)/arch/riscv/configs/64-bit.config) $(word 3,$(subst /, ,$@))
 	touch -c $@
 
 kernel/rv32gc/all%config/.config: \
 		toolchain/install.stamp \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e | grep Kconfig)
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e | grep Kconfig)
 	mkdir -p $(dir $@)
 	rm -f $@
-	$(MAKE) -C linux/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- KCONFIG_ALLCONFIG=$(abspath linux/arch/riscv/configs/32-bit.config) $(word 3,$(subst /, ,$@))
+	$(MAKE) -C $(LINUX)/ O=$(abspath $(dir $@)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- KCONFIG_ALLCONFIG=$(abspath $(LINUX)/arch/riscv/configs/32-bit.config) $(word 3,$(subst /, ,$@))
 	touch -c $@
 
 #check: extmod/stamp
@@ -148,18 +156,18 @@ extmod/stamp: \
 		kernel/rv64gc/defconfig/.config \
 		toolchain/install.stamp \
 		$(GCC) \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e)
-	$(MAKE) -C extmod/ ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- KDIR=$(abspath linux) O=$(abspath $(dir $<))
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e)
+	$(MAKE) -C extmod/ ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- KDIR=$(abspath $(LINUX)) O=$(abspath $(dir $<))
 
 check: check/dt_check/report
 
 check/dt_check/log: \
 		$(GCC) \
-		$(shell git -C linux ls-files | sed 's@^@linux/@' | xargs readlink -e)
+		$(shell git -C $(LINUX) ls-files | sed 's@^@$(LINUX)/@' | xargs readlink -e)
 	@rm -rf $(dir $@)
 	@mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath linux) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) defconfig
-	$(MAKE) -C $(abspath linux) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) dt_binding_check dtbs_check |& tee $@
+	$(MAKE) -C $(abspath $(LINUX)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) defconfig
+	$(MAKE) -C $(abspath $(LINUX)) ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- O=$(abspath $(dir $@)) dt_binding_check dtbs_check |& tee $@
 
 check/dt_check/report: check/dt_check/log
 	cat $< | grep -v '^  ' | grep -v '^make' > $@


### PR DESCRIPTION
My CI runs in docker containers that are rebuilt every run & the bottleneck of any test is the time taken for a checkout.
Usually I avoid this by doing clones of the kernel with a local reference so the download from github/kernel.org itself is minor and by building my toolchain in advance. I'll probably want to do the same overwrite for the qemu directory in the future too, but for now I've only added the overrides for the things my CI already provides.

Secondly, if I am going to run this on linux-next, it makes sense to me to allow the test run to complete even if dt_binding_check produces an error - there's often random schema errors & it'd be pretty annoying if some random maintainer not being careful about what bindings they put on their for-next blocked everything else from running.
At the very least, there's no reason for a schema error in a single example to prevent running dtbs_check.

As an aside, I have been running it like `make check report LINUX=/stuff/linux/ GCC=/stuff/tc-install/riscv64-unknown-linux-gnu-gcc -j 12`. I assume I can just check the exit code of Make for my pass/fail.