### PR TITLE
Add support for testing with LLVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /userspace
 /kernel
 /toolchain
+/llvm

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,7 @@
 [submodule "sparse"]
 	path = sparse
 	url = https://git.kernel.org/pub/scm/linux/kernel/git/palmer/sparse.git
+[submodule "llvm-project"]
+	path = llvm-project
+	url = https://github.com/llvm/llvm-project
+	branch = release/15.x

--- a/tools/make-qemu-wrapper
+++ b/tools/make-qemu-wrapper
@@ -34,7 +34,7 @@ do
     in
     \$0)                        shift 1;;
     --output)   stdout="\$2";   shift 2;;
-    */kernel)   kernel="\$1";   shift 1;;
+    */kernel-*)   kernel="\$1";   shift 1;;
     */initrd)   initrd="\$1";   shift 1;;
     */stdin)    stdin="\$1";    shift 1;;
     *) exit 1;;


### PR DESCRIPTION
I was able to test individual targets to make sure the logic worked correctly but just running `make` results in an error and it is not immediately apparent to me where things are failing. It does appear like my system is not set up to run `dtbs_check`, as I appear to be missing some `python` packages so that could just be it. I can take a look at that on either Monday or Tuesday before I go on vacation but I wanted to get this out for early review.

cc @ConchuOD